### PR TITLE
[Add] Dynamically modifying fields: 같은 모델인데 매번 serializer를 만들어야하나 고민하다 찾은 방법

### DIFF
--- a/teampang/meeting/serializer.py
+++ b/teampang/meeting/serializer.py
@@ -2,6 +2,26 @@ from .models import Plan, DummyPlan
 from rest_framework import serializers
 from rest_framework.fields import CurrentUserDefault
 
+class DynamicFieldsModelSerializer(serializers.ModelSerializer):
+    """
+    A ModelSerializer that takes an additional `fields` argument that
+    controls which fields should be displayed.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Don't pass the 'fields' arg up to the superclass
+        fields = kwargs.pop('fields', None)
+
+        # Instantiate the superclass normally
+        super(DynamicFieldsModelSerializer, self).__init__(*args, **kwargs)
+
+        if fields is not None:
+            # Drop any fields that are not specified in the `fields` argument.
+            allowed = set(fields)
+            existing = set(self.fields)
+            for field_name in existing - allowed:
+                self.fields.pop(field_name)
+
 class DummyPlanSerializer(serializers.ModelSerializer):
 
     class Meta:
@@ -26,7 +46,7 @@ class CreateUnconfirmedPlanSerializer(serializers.ModelSerializer):
         author = serializers.HiddenField(default=serializers.CurrentUserDefault())
         print("hello")
 
-class PlanSerializer(serializers.ModelSerializer):
+class PlanSerializer(DynamicFieldsModelSerializer):
 
     class Meta:
         model = Plan

--- a/teampang/meeting/views.py
+++ b/teampang/meeting/views.py
@@ -33,22 +33,25 @@ class PlanViewSet(viewsets.ModelViewSet):
     def getPlanList(self, request):
         plan = request.user.plans.all()
         serializer = MainPagePlanListSerializer(plan, many=True)
+        #serializer = PlanSerializer(plan, fields=('name', 'confirmed_date'), many=True) #dynamic serializer fields
         return Response(serializer.data, status=200)
+
 #################### page 4-1 ####################
-    @action(detail = True, methods = ["POST"])
-    # confirmed date 제외하고 생성
-    def makeUnconfirmedPlan(self, request, pk):
-        # user = serializers.HiddenField(
-        #    default=serializers.CurrentUserDefault(),
-        # )   
-        #permission_classes = (IsAuthenticated,)
-        serializer = CreateUnconfirmedPlanSerializer(data=request.data)
-        print(CurrentUserDefault())
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data, status=201)
-        else:
-            return Response(serializer.errors, status=400)
+    # @action(detail = True, methods = ["POST"])
+    # # confirmed date 제외하고 생성
+    # def makeUnconfirmedPlan(self, request, pk):
+    #     # user = serializers.HiddenField(
+    #     #    default=serializers.CurrentUserDefault(),
+    #     # )   
+    #     #permission_classes = (IsAuthenticated,)
+    #     #serializer = CreateUnconfirmedPlanSerializer(data=request.data)
+    #     serializer = PlanSerializer(fields=(name, ))
+    #     print(CurrentUserDefault())
+    #     if serializer.is_valid():
+    #         serializer.save()
+    #         return Response(serializer.data, status=201)
+    #     else:
+    #         return Response(serializer.errors, status=400)
 
 #################### page 4-2 ####################
     @action(detail = True, methods = ["GET"])


### PR DESCRIPTION
```python 
def getPlanList(self, request):
        plan = request.user.plans.all()
        serializer = MainPagePlanListSerializer(plan, many=True)
        #serializer = PlanSerializer(plan, fields=('name', 'confirmed_date'), many=True) #dynamic serializer fields
        return Response(serializer.data, status=200)
```

주석 처리한  부분이 적용 예입니다!
아주 편리하게 쓰일거 같아요!

[참고-장고공식문서]
https://www.django-rest-framework.org/api-guide/serializers/#declaring-serializers